### PR TITLE
chore: update support-bundle-kit to v0.0.65

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -85,6 +85,6 @@
     },
     "support-bundle-kit": {
         "repo": "https://github.com/rancher/support-bundle-kit.git",
-        "tag": "v0.0.64"
+        "tag": "v0.0.65"
     }
 }


### PR DESCRIPTION
longhorn/longhorn#8397

support-bundle-kit:v0.0.65 is mirrored.
https://ci.longhorn.io/job/private/job/mirror-csi-images/64/