### PR TITLE
chore(v1.9.6): update versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -79,6 +79,6 @@
     },
     "support-bundle-kit": {
         "repo": "https://github.com/rancher/support-bundle-kit.git",
-        "tag": "v0.0.85"
+        "tag": "v0.0.87"
     }
 }

--- a/versions.json
+++ b/versions.json
@@ -55,7 +55,7 @@
     },
     "csi-attacher": {
         "repo": "https://github.com/kubernetes-csi/external-attacher.git",
-        "tag": "v4.11.0-20260428"
+        "tag": "v4.12.0"
     },
     "csi-provisioner": {
         "repo": "https://github.com/kubernetes-csi/external-provisioner.git",
@@ -67,15 +67,15 @@
     },
     "csi-snapshotter": {
         "repo": "https://github.com/kubernetes-csi/external-snapshotter.git",
-        "tag": "v8.5.0-20260428"
+        "tag": "v8.6.0"
     },
     "csi-node-driver-registrar": {
         "repo": "https://github.com/kubernetes-csi/node-driver-registrar.git",
-        "tag": "v2.16.0-20260428"
+        "tag": "v2.17.0"
     },
     "livenessprobe": {
         "repo": "https://github.com/kubernetes-csi/livenessprobe.git",
-        "tag": "v2.18.0-20260428"
+        "tag": "v2.19.0"
     },
     "support-bundle-kit": {
         "repo": "https://github.com/rancher/support-bundle-kit.git",


### PR DESCRIPTION
Update the CSI sidecar components to the latest available versions.
There is no need to address the CVEs, as Longhorn v1.9.6 will not be released publicly.

Signed-off-by: Derek Su <derek.su@suse.com>