### PR TITLE
feat: add libqcow build script and version for v1.9.x

### DIFF
--- a/scripts/build-libqcow.sh
+++ b/scripts/build-libqcow.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Illegal number of parameters"
+    exit 1
+fi
+
+MAIN_DIR=$(dirname $(dirname $(realpath $0)))
+
+REPO_OVERRIDE="$1"
+COMMIT_ID_OVERRIDE="$2"
+SRC_DIR="/usr/src/libqcow"
+
+# Fetch repo and commit ID from versions.json, with optional overrides
+LIBQCOW_REPO=$(jq -r '.["libqcow"].repo' ${MAIN_DIR}/versions.json)
+LIBQCOW_COMMIT_ID=$(jq -r '.["libqcow"].commit' ${MAIN_DIR}/versions.json)
+
+# Apply overrides if provided
+if [[ -n "$REPO_OVERRIDE" ]]; then
+    LIBQCOW_REPO="$REPO_OVERRIDE"
+fi
+
+if [[ -n "$COMMIT_ID_OVERRIDE" ]]; then
+    LIBQCOW_COMMIT_ID="$COMMIT_ID_OVERRIDE"
+fi
+
+# Clone the repository
+git clone "$LIBQCOW_REPO" "$SRC_DIR"
+
+# Checkout the specific commit
+cd "$SRC_DIR"
+git checkout "$LIBQCOW_COMMIT_ID"
+
+# Build and install
+autoreconf -i
+./configure
+make -j$(nproc)
+make install

--- a/versions.json
+++ b/versions.json
@@ -53,6 +53,12 @@
         "tag": "v6.3",
         "description": "ntirpc is a new transport-agnostic RPC library that is being developed as part of the NFS-Ganesha project."
     },
+    "libqcow": {
+        "repo": "https://github.com/longhorn/libqcow.git",
+        "commit": "be16287a2b9691347936be43fcffe93b8f74cf54",
+        "tag": "v1.0.0",
+        "description": "libqcow is a library for reading and writing QCOW2 files, which are used by QEMU for disk images."
+    },
     "csi-attacher": {
         "repo": "https://github.com/kubernetes-csi/external-attacher.git",
         "tag": "v4.12.0"


### PR DESCRIPTION
Backport libqcow to v1.9.x. Needed by longhorn/longhorn-engine[#1888](https://github.com/longhorn/longhorn-engine/pull/1888).