### PR TITLE
fix: change csi-provisioner tag version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -65,7 +65,7 @@
   },
   "csi-provisioner": {
     "repo": "https://github.com/kubernetes-csi/external-provisioner.git",
-    "tag": "v6.3.0"
+    "tag": "v5.3.0"
   },
   "csi-resizer": {
     "repo": "https://github.com/kubernetes-csi/external-resizer.git",


### PR DESCRIPTION
Updated csi-provisioner tag from v6.3.0 to v5.3.0.

Longhorn/longhorn#13505