### PR TITLE
build(spdk): enable RDMA NVMe-oF transport (--with-rdma)

### DIFF
--- a/scripts/build-spdk.sh
+++ b/scripts/build-spdk.sh
@@ -37,19 +37,19 @@ git submodule update --init
 # Modify package dependency script for SLES
 sed -i '/python3-pyelftools/d' ./scripts/pkgdep/sles.sh
 
-# Install dependencies
-./scripts/pkgdep.sh --uring
+# Install dependencies (--rdma pulls libibverbs/librdmacm/rdma-core dev libs for the NVMe-oF RDMA transport)
+./scripts/pkgdep.sh --uring --rdma
 pip3 install -r ./scripts/pkgdep/requirements.txt
 
 # Build and install based on architecture
 case "$ARCH" in
     amd64)
-        ./configure --target-arch=nehalem --disable-tests --disable-unit-tests --disable-examples --with-ublk --enable-debug
+        ./configure --target-arch=nehalem --disable-tests --disable-unit-tests --disable-examples --with-ublk --with-rdma --enable-debug
         make -j"$(nproc)"
         make install
         ;;
     arm64)
-        CFLAGS="-march=armv8-a" CC="gcc-13" ./configure --target-arch=armv8-a --disable-tests --disable-unit-tests --disable-examples --with-ublk --enable-debug
+        CFLAGS="-march=armv8-a" CC="gcc-13" ./configure --target-arch=armv8-a --disable-tests --disable-unit-tests --disable-examples --with-ublk --with-rdma --enable-debug
         DPDKBUILD_FLAGS="-Dplatform=generic" make -j"$(nproc)"
         make install
         ;;


### PR DESCRIPTION
Part of longhorn/longhorn#13796.

Add `--rdma` to `pkgdep.sh` and `--with-rdma` to both the x86 (nehalem) and arm64 (armv8-a) SPDK `./configure` lines so `spdk_tgt` links `libibverbs`/`librdmacm` and can create an RDMA NVMe-oF transport. Load-bearing for the v2 data-engine RDMA transport; no effect unless a volume selects `dataEngineTransport: rdma`.

This PR is independent of the 5-repo Go change and can merge on its own.

File: `scripts/build-spdk.sh`.
